### PR TITLE
remove 1am appt gen language, add request to not ask for serum

### DIFF
--- a/index.html
+++ b/index.html
@@ -85,10 +85,11 @@
                                     <p class="font-md text-left">The results of your swab testing will be provided to you via email or phone within 24 to 48 hours. The processing of blood samples are currently underway and your results may take several weeks. Since this is a research test, please confirm your test results via standard CDC testing as feasible.</p>
                                     <!-- <p class="font-md text-left">New appointments are added daily at 01:00. Please check back tomorrow if there is no availability.</p> -->
                                     <p class="font-md text-left">If you are currently sick or exhibiting symptoms please contact your health care provider.</p>
-                                    <p class="font-md text-left"><strong>If you would like to have antibody testing (SERUM), please note these appointments are only available at the Main UF Health Shands ER from 700 to 1200. The appointments are limited and are denoted by the name UFEDSERUM. The table below will let you know if any are available. New appointments are released daily at 01:00.</strong></p>
+                                    <p class="font-md text-left"><strong>If you would like to have antibody testing (SERUM), please note these appointments are only available at the Main UF Health Shands ER from 700 to 1200. The appointments are limited and are denoted by the name UFEDSERUM. The table below is updated automatically, it will let you know if any are available.</strong></p>
                                     <table id="appointment_table" class="table table-responsive">
                                     </table>
                                     <p class="font-md text-left">This survey may take between 5-10 minutes. All of your responses and participation will be completely confidential.</p>
+                                    <p class="font-md text-left">If there are no serum appointments available, please <strong>do not email or call</strong> asking to be scheduled for one. Exceptions can not be made.</p>
                                     <div class="buttons inpage-scroll">
                                         <a href="https://redcap.ctsi.ufl.edu/redcap/surveys/?s=MEKJKFKJEP" target="_blank" class="btn btn-primary custom-button red-btn">REGISTER</a>
                                     </div>


### PR DESCRIPTION
Removes sentence stating new appointments are generated daily at 01:00.  
Adds language discouraging visitors from contacting coordinators to ask for serum appointments when there are none.

![image](https://user-images.githubusercontent.com/20332546/80759753-d00f9180-8b05-11ea-9204-7504dd26a6f7.png)
